### PR TITLE
Pgp sig

### DIFF
--- a/imap/handlers/fetch.cpp
+++ b/imap/handlers/fetch.cpp
@@ -1345,11 +1345,21 @@ EString Fetch::bodyStructure( Multipart * m, bool extended )
 
     Header * hdr = m->header();
     ContentType * ct = hdr->contentType();
+    
+    bool inMultipartSigned = false;
 
     if ( ct && ct->type() == "multipart" ) {
+        if ( ct->subtype() == "signed" ) {
+            inMultipartSigned = true;
+        }
         EStringList children;
         List< Bodypart >::Iterator it( m->children() );
         while ( it ) {
+            if ( inMultipartSigned ) {
+                ++it; // skip next child-structure, as we appended it already raw
+                inMultipartSigned = false;
+            }
+            Header * h = it->header();
             children.append( bodyStructure( it, extended ) );
             ++it;
         }

--- a/message/bodypart.cpp
+++ b/message/bodypart.cpp
@@ -19,7 +19,7 @@ class BodypartData
 {
 public:
     BodypartData()
-        : id( 0 ), number( 0 ), message( 0 ),
+        : id( 0 ), number( 1 ), message( 0 ),
           numBytes( 0 ), numEncodedBytes(), numEncodedLines( 0 ),
           hasText( false )
     {}
@@ -36,7 +36,6 @@ public:
     EString data;
     UString text;
     bool hasText;
-    bool isPgpSigned;
     EString error;
 };
 
@@ -62,7 +61,6 @@ Bodypart::Bodypart()
     : d ( new BodypartData )
 {
     setHeader( new Header( Header::Mime ) );
-    setPgpSigned( false );
 }
 
 
@@ -74,7 +72,6 @@ Bodypart::Bodypart( uint n, Multipart * p )
     setHeader( new Header( Header::Mime ) );
     d->number = n;
     setParent( p );
-    setPgpSigned( false );
 }
 
 
@@ -372,7 +369,6 @@ void Bodypart::parseMultipart( uint i, uint end,
                     if ( isPgpSigned ) {
                         // store the complete to-be-signed part, incl. header(s), to keep the unchanged version
                         Bodypart * bpt = new Bodypart( 0, parent );
-                        bpt->setPgpSigned( true );  // really needed ?
                         bpt->setData( rfc2822.mid(sigstart, i - sigstart) );
                         bpt->setNumBytes( i - sigstart );
                         children->append( bpt );
@@ -750,7 +746,8 @@ Bodypart * Bodypart::parseBodypart( uint start, uint end,
             // there may be exceptions. cases where some format really
             // needs another content-transfer-encoding:
             if ( ct->type() == "application" &&
-                 ct->subtype().startsWith( "pgp-" ) ) { // hgu: removed:  &&  !body.needsQP() ) {
+                 ct->subtype().startsWith( "pgp-" ) &&
+                 !body.needsQP() ) {
                 // seems some PGP things need "Version: 1" unencoded
                 e = EString::Binary;
             }
@@ -859,14 +856,4 @@ bool Bodypart::isBodypart() const
 EString Bodypart::error() const
 {
     return d->error;
-}
-
-bool Bodypart::isPgpSigned()
-{
-    return d->isPgpSigned;
-}
-
-void Bodypart::setPgpSigned( bool isSigned )
-{
-    d->isPgpSigned = isSigned;
 }

--- a/message/bodypart.h
+++ b/message/bodypart.h
@@ -58,9 +58,6 @@ public:
                                 const EString &, bool,
                                 List< Bodypart > *, Multipart *, bool );
 
-    bool isPgpSigned();
-    void setPgpSigned( bool );
-
 private:
     class BodypartData * d;
     friend class Message;

--- a/message/bodypart.h
+++ b/message/bodypart.h
@@ -56,7 +56,11 @@ public:
 
     static void parseMultipart( uint, uint, const EString &,
                                 const EString &, bool,
-                                List< Bodypart > *, Multipart * );
+                                List< Bodypart > *, Multipart *, bool );
+
+    bool isPgpSigned();
+    void setPgpSigned( bool );
+
 private:
     class BodypartData * d;
     friend class Message;

--- a/message/header.cpp
+++ b/message/header.cpp
@@ -19,7 +19,7 @@
 #include "codec.h"
 #include "date.h"
 #include "utf.h"
-
+#include "log.h"
 
 
 static const char *crlf = "\015\012";
@@ -115,6 +115,7 @@ EString Header::error() const
 
 void Header::add( HeaderField * hf )
 {
+    ::log( "Header::add - name:" + hf->name(), Log::Debug );
     HeaderField::Type t = hf->type();
 
     if ( t == HeaderField::To || t == HeaderField::Cc ||
@@ -156,6 +157,7 @@ void Header::add( HeaderField * hf )
 
 void Header::add( const EString &name, const EString &value )
 {
+    ::log( "Header::add - create name:" + name + "=" + value, Log::Debug );
     add( HeaderField::create( name, value ) );
 }
 
@@ -167,8 +169,12 @@ void Header::removeField( HeaderField::Type t )
 {
     List<HeaderField>::Iterator it( d->fields );
     while ( it ) {
-        if ( it->type() == t )
+        if ( it->type() == t ) {
+            ::log( "Header::removeField - type:", Log::Debug );
+            ::log( HeaderField::fieldName(t), Log::Debug );
+            ::log( "Header::removeField - name:" + it->name(), Log::Debug );
             d->fields.take( it );
+        }
         else
             ++it;
     }
@@ -183,6 +189,8 @@ void Header::removeField( HeaderField::Type t )
 
 void Header::removeField( const char * n )
 {
+    ::log( "Header::removeField - name:", Log::Debug );
+    // ::log( n, Log::Debug );
     List<HeaderField>::Iterator it( d->fields );
     while ( it ) {
         if ( it->name() == n )
@@ -565,6 +573,7 @@ static bool sameAddresses( AddressField *a, AddressField *b )
 
 void Header::simplify()
 {
+    ::log( "Header::simplify", Log::Debug );
     if ( !valid() )
         return;
 
@@ -578,13 +587,15 @@ void Header::simplify()
 
     HeaderField *cde = field( HeaderField::ContentDescription );
     if ( cde && cde->rfc822( false ).isEmpty() ) {
+        ::log( "Header::simplify - removeField Content-Description", Log::Debug );
         removeField( HeaderField::ContentDescription );
         cde = 0;
     }
 
     ContentTransferEncoding *cte = contentTransferEncoding();
-    if ( cte && cte->encoding() == EString::Binary )
+    if ( cte && cte->encoding() == EString::Binary ) {
         removeField( HeaderField::ContentTransferEncoding );
+    }
 
     ContentDisposition *cdi = contentDisposition();
     if ( cdi ) {
@@ -594,6 +605,7 @@ void Header::simplify()
              cdi->disposition() == ContentDisposition::Inline &&
              cdi->parameters()->isEmpty() )
         {
+            ::log( "Header::simplify - removeField ContentDisposition", Log::Debug );
             removeField( HeaderField::ContentDisposition );
             cdi = 0;
         }
@@ -604,32 +616,40 @@ void Header::simplify()
         if ( ct->parameters()->isEmpty() && cte == 0 && cdi == 0 && cde == 0 &&
              d->defaultType == TextPlain &&
              ct->type() == "text" && ct->subtype() == "plain" ) {
+            ::log( "Header::simplify - removeField ContentType", Log::Debug );
             removeField( HeaderField::ContentType );
             ct = 0;
         }
     }
     else if ( d->defaultType == MessageRfc822 ) {
+        ::log( "Header::simplify - add Content-Type=message/rfc822", Log::Debug );
         add( "Content-Type", "message/rfc822" );
         ct = contentType();
     }
 
     if ( mode() == Mime ) {
+        ::log( "Header::simplify - removeField MimeVersion (1)", Log::Debug );
         removeField( HeaderField::MimeVersion );
     }
     else if ( ct == 0 && cte == 0 && cde == 0 && cdi == 0 &&
          !field( HeaderField::ContentLocation ) &&
          !field( "Content-Base" ) ) {
+        ::log( "Header::simplify - removeField MimeVersion (2)", Log::Debug );
         removeField( HeaderField::MimeVersion );
     }
     else {
-        if ( mode() == Rfc2822 && !field( HeaderField::MimeVersion ) )
+        if ( mode() == Rfc2822 && !field( HeaderField::MimeVersion ) ) {
+            ::log( "Header::simplify - add MimeVersion", Log::Debug );
             add( "Mime-Version", "1.0" );
+        }
     }
     if ( ct &&
          ( ct->type() == "multipart" || ct->type() == "message" ||
            ct->type() == "image" || ct->type() == "audio" ||
-           ct->type() == "video" ) )
+           ct->type() == "video" ) ) {
+        ::log( "Header::simplify - removeParameter charset", Log::Debug );
         ct->removeParameter( "charset" );
+    }
 
     if ( field( "Errors-To" ) ) {
         EString et = field( "Errors-To" )->value().ascii();
@@ -673,12 +693,15 @@ void Header::simplify()
 
 void Header::repair()
 {
-    if ( valid() )
+    if ( valid() ) {
+        ::log( "Header::repair plain - nothing to repair", Log::Debug );
         return;
+    }
 
     // We remove duplicates of any field that may occur only once.
     // (Duplication has been observed for Date/Subject/M-V/C-T-E/C-T/M-I.)
 
+    ::log( "Header::repair plain - repair things", Log::Debug );
     uint occurrences[ (int)HeaderField::Other ];
     int i = 0;
     while ( i < HeaderField::Other )
@@ -865,9 +888,12 @@ void Header::repair()
 
 void Header::repair( Multipart * p, const EString & body )
 {
-    if ( valid() )
+    if ( valid() ) {
+        ::log( "Header::repair multipart - nothing to repair", Log::Debug );
         return;
+    }
 
+    ::log( "Header::repair multipart - repair things", Log::Debug );
     // Duplicated from above.
     uint occurrences[ (int)HeaderField::Other ];
     int i = 0;
@@ -1468,7 +1494,7 @@ void Header::repair( Multipart * p, const EString & body )
         Bodypart::parseMultipart( 0, body.length(), body,
                                   ct->parameter( "boundary" ),
                                   false,
-                                  tmp->children(), tmp );
+                                  tmp->children(), tmp, false ); // hgu: TDB: temporary, RETHINK !!
         List<Bodypart>::Iterator i( tmp->children() );
         Address * postmaster = 0;
         while ( i && !postmaster ) {
@@ -1830,6 +1856,7 @@ static int msgidness( const Address * a )
 
 void Header::fix8BitFields( class Codec * c )
 {
+    ::log( "Header::fix8BitFields", Log::Debug );
     d->verified = false;
 
     Utf8Codec utf8;

--- a/message/message.cpp
+++ b/message/message.cpp
@@ -91,11 +91,14 @@ void Message::parse( const EString & rfc2822 )
     header()->repair( this, rfc2822.mid( i ) );
 
     ContentType * ct = header()->contentType();
+    bool isPgpSigned = false;
     if ( ct && ct->type() == "multipart" ) {
+        if ( ct->subtype() == "signed" )
+            isPgpSigned = true;
         Bodypart::parseMultipart( i, rfc2822.length(), rfc2822,
                                   ct->parameter( "boundary" ),
                                   ct->subtype() == "digest",
-                                  children(), this );
+                                  children(), this, isPgpSigned );
     }
     else {
         Bodypart * bp = Bodypart::parseBodypart( i, rfc2822.length(), rfc2822,

--- a/message/message.cpp
+++ b/message/message.cpp
@@ -100,11 +100,9 @@ void Message::parse( const EString & rfc2822 )
                                   ct->subtype() == "digest",
                                   children(), this, isPgpSigned );
     }
-    else {
-        Bodypart * bp = Bodypart::parseBodypart( i, rfc2822.length(), rfc2822,
+    Bodypart * bp = Bodypart::parseBodypart( i, rfc2822.length(), rfc2822,
                                                  header(), this );
-        children()->append( bp );
-    }
+    children()->append( bp );
 
     fix8BitHeaderFields();
     header()->simplify();

--- a/message/message.cpp
+++ b/message/message.cpp
@@ -100,9 +100,11 @@ void Message::parse( const EString & rfc2822 )
                                   ct->subtype() == "digest",
                                   children(), this, isPgpSigned );
     }
-    Bodypart * bp = Bodypart::parseBodypart( i, rfc2822.length(), rfc2822,
+    else {
+        Bodypart * bp = Bodypart::parseBodypart( i, rfc2822.length(), rfc2822,
                                                  header(), this );
-    children()->append( bp );
+        children()->append( bp );
+    }
 
     fix8BitHeaderFields();
     header()->simplify();

--- a/message/mimefields.cpp
+++ b/message/mimefields.cpp
@@ -585,18 +585,24 @@ void ContentTransferEncoding::parse( const EString &s )
     // XXX shouldn't we do p.end() here and record parse errors?
 
     if ( t == "7bit" || t == "8bit" || t == "8bits" || t == "binary" ||
-         t == "unknown" )
+         t == "unknown" ) {
         setEncoding( EString::Binary );
-    else if ( t == "quoted-printable" )
+    }
+    else if ( t == "quoted-printable" ) {
         setEncoding( EString::QP );
-    else if ( t == "base64" )
+    }
+    else if ( t == "base64" ) {
         setEncoding( EString::Base64 );
-    else if ( t == "x-uuencode" || t == "uuencode" )
+    }
+    else if ( t == "x-uuencode" || t == "uuencode" ) {
         setEncoding( EString::Uuencode );
-    else if ( t.contains( "bit" ) && t[0] >= '0' && t[0] <= '9' )
+    }
+    else if ( t.contains( "bit" ) && t[0] >= '0' && t[0] <= '9' ) {
         setEncoding( EString::Binary );
-    else
+    }
+    else {
         setError( "Invalid c-t-e value: " + t.quoted() );
+    }
 }
 
 

--- a/message/mimefields.cpp
+++ b/message/mimefields.cpp
@@ -585,24 +585,18 @@ void ContentTransferEncoding::parse( const EString &s )
     // XXX shouldn't we do p.end() here and record parse errors?
 
     if ( t == "7bit" || t == "8bit" || t == "8bits" || t == "binary" ||
-         t == "unknown" ) {
+         t == "unknown" )
         setEncoding( EString::Binary );
-    }
-    else if ( t == "quoted-printable" ) {
+    else if ( t == "quoted-printable" )
         setEncoding( EString::QP );
-    }
-    else if ( t == "base64" ) {
+    else if ( t == "base64" )
         setEncoding( EString::Base64 );
-    }
-    else if ( t == "x-uuencode" || t == "uuencode" ) {
+    else if ( t == "x-uuencode" || t == "uuencode" )
         setEncoding( EString::Uuencode );
-    }
-    else if ( t.contains( "bit" ) && t[0] >= '0' && t[0] <= '9' ) {
+    else if ( t.contains( "bit" ) && t[0] >= '0' && t[0] <= '9' )
         setEncoding( EString::Binary );
-    }
-    else {
+    else
         setError( "Invalid c-t-e value: " + t.quoted() );
-    }
 }
 
 

--- a/message/multipart.cpp
+++ b/message/multipart.cpp
@@ -104,9 +104,9 @@ void Multipart::appendMultipart( EString &r, bool avoidUtf8 ) const
         ++it;
         
         if ( isSigned ) {
-            ++it;
+            ++it;       // skip next part, we append it raw
             isSigned = false;
-            // we do not want our simple header, just append our raw text
+            // just append our raw text, header is contained
             appendAnyPart( r, bp, ct, avoidUtf8 );
         } else {
             r.append( bp->header()->asText( avoidUtf8 ) );
@@ -147,12 +147,15 @@ void Multipart::appendAnyPart( EString &r, const Bodypart * bp,
         else
             r.append( bp->message()->rfc822( avoidUtf8 ) );
     }
-    else if ( !childct || childct->type().lower() == "text" )
+    else if ( !childct || childct->type().lower() == "text" ) {
         appendTextPart( r, bp, childct );
-    else if ( childct->type() == "multipart" )
+    }
+    else if ( childct->type() == "multipart" ) {
         bp->appendMultipart( r, avoidUtf8 );
-    else
+    }
+    else {
         r.append( bp->data().encoded( e, 72 ) );
+    }
 }
 
 


### PR DESCRIPTION
Due to the architecture of aox, only *inline* PGP signatures did verify. This patch enhences aox to support OpenPGP/MIME signed messages (RFC 4880 and 3156) for both signature creation and verification.
Messages of Content-Type: multipart/signed store the part before the sig in raw format additionally to the usual structure format. 
The raw bodypart is being skipped in Fetch:bodyStructure but used in appendMultipart. The opposite is true for the extended body structure.
