### PR TITLE
Fix fromNumber failing to handle negative int64 numbers

### DIFF
--- a/core/estring.cpp
+++ b/core/estring.cpp
@@ -946,7 +946,15 @@ uint EString::number( bool * ok, uint base ) const
 EString EString::fromNumber( int64 n, uint base )
 {
     EString r;
-    r.appendNumber( n, base );
+    if (0 == n) {
+        r.append("0");        // Short-circuit, 0 is 0 in any base, no need for extra processing
+    } else {
+        if (n < 0) {
+            n = -n;        // Negate, otherwise negative numbers get messed up
+            r.append("-");    // But we remember we need a - sign
+        }
+        r.appendNumber( n, base );
+    }
     return r;
 }
 


### PR DESCRIPTION
appendNumber only handles positive numbers, but fromNumber(int64 n,unit base)
was passing a negative value to it which resulted in an invalid result string
which then cascaded into causing PostgreSQL syntax errors and caused queries
to fail.

See discussion on aox-users 2016-SEP.