### PR TITLE
NULL Mailbox Flag emits alarming log noise

### DIFF
--- a/server/mailbox.cpp
+++ b/server/mailbox.cpp
@@ -141,7 +141,10 @@ void MailboxReader::execute() {
                                     r->getBigint( "nextmodseq" ),
                                     q->transaction() );
 
-        m->setFlag( r->getEString( "flag" ) );
+        if ( !r->isNull( "flag" ) )
+            m->setFlag( r->getEString( "flag" ) );
+        else
+            m->setFlag( "" );
     }
 
     if ( !q->done() || done )


### PR DESCRIPTION
Schema V98 added `mailboxes.flag` which is _nullable_, but the software generates a lot of warning noise as `getEString()` implicitly handles a conversion to empty-string.

This is most likely observed in log output during server startup or when running commands that retrieve mailbox information, e.g.:

`aox: Note: Expected type string for column "flag", but received null`

This patch avoids the warning my making the conversion explicit.