### PR TITLE
Log reason if OpenSSL fails to load the certificate.

### DIFF
--- a/aox/servers.cpp
+++ b/aox/servers.cpp
@@ -1116,7 +1116,7 @@ static void selfSignCertificate()
     if ( r == -1 )
         error( "Needed to execute openssl req, but failed" );
 
-    // one one hand, File::write() does no checking. On the other,
+    // on one hand, File::write() does no checking. On the other,
     // this does at least not pass user-supplied data to the shell.
     File ossl( "/tmp/aox-ossl.pem" );
     File result( keyFile, File::Write );

--- a/server/tlsthread.cpp
+++ b/server/tlsthread.cpp
@@ -116,9 +116,12 @@ void TlsThread::setup()
         keyFile = certFile;
     else
         keyFile = File::chrooted( keyFile );
-    if ( !SSL_CTX_use_certificate_chain_file( ctx, certFile.cstr() ) )
-        log( "OpenSSL needs the certificate in this file: " + keyFile,
+    if ( !SSL_CTX_use_certificate_chain_file( ctx, certFile.cstr() ) ) {
+        EString reason = ERR_reason_error_string(ERR_peek_error());
+        log( "OpenSSL failed to read the certificate from " + keyFile +
+             ": " + reason,
              Log::Disaster );
+    }
     if ( !SSL_CTX_use_RSAPrivateKey_file( ctx, keyFile.cstr(),
                                           SSL_FILETYPE_PEM ) )
         log( "OpenSSL needs the private key in this file: " + keyFile,


### PR DESCRIPTION
Helped me to debug a problem:

$ sudo /usr/local/archiveopteryx/bin/aox start
Archiveopteryx: OpenSSL failed to read the certificate from /usr/local/archiveopteryx/lib/automatic-key.pem: ee key too small