### PR TITLE
Fixed format of quota responses.

### DIFF
--- a/imap/handlers/quota.cpp
+++ b/imap/handlers/quota.cpp
@@ -55,7 +55,7 @@ void GetQuota::execute()
     if ( r )
         respond( "QUOTA \"\" ("
                  "STORAGE " + fn( r->getBigint( "s" ) ) + " " + quota + " "
-                 "MESSAGE " + fn( r->getBigint( "c" ) ) + "  " + quota + ")" );
+                 "MESSAGE " + fn( r->getBigint( "c" ) ) + " " + quota + ")" );
     finish();
 }
 


### PR DESCRIPTION
RFC2087 defines the resources response for GETQUOTA and GETQUOTAROOT with this syntax:

  quota_resource  ::= atom SP number SP number

Thus, the doubled space is not allowed. Alpine complained.