### PR TITLE
Remove extranneous space character

### DIFF
--- a/imap/handlers/id.cpp
+++ b/imap/handlers/id.cpp
@@ -67,6 +67,6 @@ void Id::execute()
              "\"version\" " + v.quoted() + " "
              "\"compile-time\" \"" __DATE__ " " __TIME__ "\" "
              "\"homepage-url\" \"http://archiveopteryx.org\" "
-             "\"release-url\" \"http://archiveopteryx.org/" + v + "\" )" );
+             "\"release-url\" \"http://archiveopteryx.org/" + v + "\")" );
     finish();
 }


### PR DESCRIPTION
This was breaking Delta Chat from logging into aox

https://github.com/deltachat/deltachat-core-rust/issues/5513