### PR TITLE
Fix the build

### DIFF
--- a/message/Jamfile
+++ b/message/Jamfile
@@ -24,10 +24,10 @@ rule DomainList
 
 actions DomainList
 {
-    sed -e 's/;.*//' < $(>) -e 's/\.\s/ /' | \
+    sed -e 's/;.*//' < $(>) -e 's/\.[ \t]/ /' | \
         expand -8 | \
         tr '[A-Z]' '[a-z]' | \
-        grep '^[a-z0-9-]*\s' \
+        grep '^[a-z0-9-]*\s' | \
 	awk '{print $1}' | sort -u | xargs -n1 idn2 --decode | \
         awk '{print "{ " length($1) ", \"" $1 "\" },\n" }' | \
         sort -u | \
@@ -42,7 +42,7 @@ DomainList tld.inc : root.zone ;
 Build message :
     multipart.cpp message.cpp bodypart.cpp header.cpp parser.cpp
     field.cpp mimefields.cpp datefield.cpp addressfield.cpp
-    address.cpp date.cpp flag.cpp mover.cpp
+    address.cpp date.cpp flag.cpp
     injector.cpp fetcher.cpp annotation.cpp
     dsn.cpp recipient.cpp listidfield.cpp
     messagecache.cpp helperrowcreator.cpp


### PR DESCRIPTION
1. sed \s syntax is gnu sed only; replacing \s with [ \t] or [[:space:]] should make it work cross platform
2. grep line was missing the pipe
3. mover.cpp doesn't exist in the repo