### PR TITLE
Add wildcard address support

### DIFF
--- a/deliver/aoxdeliver.cpp
+++ b/deliver/aoxdeliver.cpp
@@ -57,8 +57,14 @@ public:
                        "join addresses a on (al.address=a.id) "
                        "left join users u on (al.id=u.alias) "
                        "left join namespaces n on (u.parentspace=n.id) "
-                       "where (a.localpart=$1 and a.domain=$2) "
-                       "or (lower(u.login)=$3)", this );
+                       "where (a.domain=$2 and (a.localpart=$1 or a.localpart='*')) "
+                       "or (lower(u.login)=$3) "
+                       "order by case "
+                       "when (a.localpart=$1 and a.domain=$2) then 0 "
+                       "when (a.localpart='*' and a.domain=$2) then 1 "
+                       "when (lower(u.login)=$3) then 2 "
+                       "else 3 end "
+                       "limit 1", this );
         if ( user.contains( '@' ) ) {
             int at = user.find( '@' );
             q->bind( 1, user.mid( 0, at ) );

--- a/doc/aox.man
+++ b/doc/aox.man
@@ -165,6 +165,7 @@ Creates an alias that instructs the server to accept mail to the given
 .I address
 and deliver it to the specified
 .IR mailbox .
+An address of '*@example.com' will behave as a wildcard or catch-all address.
 .IP "aox delete alias <address>"
 Deletes an alias, if one exists, for the given
 .IR address .

--- a/sieve/sieve.cpp
+++ b/sieve/sieve.cpp
@@ -493,8 +493,10 @@ void Sieve::addRecipient( Address * address, EventHandler * user )
                        " (s.owner=m.owner and s.active='t') "
                        "left join users u on (s.owner=u.id) "
                        "left join namespaces n on (u.parentspace=n.id) "
-                       "where m.deleted='f' and "
-                       "a.localpart=$1 and a.domain=$2", this );
+                       "where m.deleted='f' and a.domain=$2 and "
+                       "(a.localpart=$1 or a.localpart='*') "
+                       "order by case when a.localpart=$1 then 0 else 1 end "
+                       "limit 1", this );
     UString localpart( address->localpart() );
     if ( Configuration::toggle( Configuration::UseSubaddressing ) ) {
         EString sep( Configuration::text( Configuration::AddressSeparator ) );


### PR DESCRIPTION
Wildcard or catch-all addresses can be created with an alias in the format of '*@example.com'. Due to shell glob expansion you must quote the wildcard address when creating the alias.

Example:

aox add alias '*@example.com' /users/username@example.com/INBOX